### PR TITLE
.NET Standard 1.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ after_test:
     - packages\OpenCover.4.6.519\tools\OpenCover.Console.exe 
         -register:user -filter:"+[Ipfs*]* -[*Tests]* -[Ipfs.Core]SHA3*" 
         -target:"c:\Program Files\dotnet\dotnet.exe" 
-        -targetargs:"test -c Release --no-build --no-restore test" 
+        -targetargs:"test -c Release --no-build --no-restore --framework netcoreapp2.0 test" 
         -output:coverage.xml  
         -mergeoutput 
         -hideskipped:File 

--- a/src/Base32.cs
+++ b/src/Base32.cs
@@ -14,7 +14,7 @@ namespace Ipfs
     ///   to encode a byte array and <see cref="FromBase32"/> to decode a Base-32 string.
     ///   </para>
     ///   <para>
-    ///   A thin wrapper around <see href="https://github.com/kappa7194/base32"/>.
+    ///   A thin wrapper around <see href="https://github.com/ssg/SimpleBase"/>.
     ///   </para>
     /// </remarks>
     public static class Base32
@@ -36,7 +36,7 @@ namespace Ipfs
         /// </returns>
         public static string Encode(byte[] input)
         {
-            return Albireo.Base32.Base32.Encode(input);
+            return SimpleBase.Base32.Rfc4648.Encode(input, true);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Ipfs
         /// </returns>
         public static byte[] Decode(string input)
         {
-            return Albireo.Base32.Base32.Decode(input);
+            return SimpleBase.Base32.Rfc4648.Decode(input);
         }
 
         /// <summary>

--- a/src/Base58.cs
+++ b/src/Base58.cs
@@ -14,7 +14,7 @@ namespace Ipfs
     ///   to encode a byte array and <see cref="FromBase58"/> to decode a Base-58 string.
     ///   </para>
     ///   <para>
-    ///   This is just thin wrapper of <see href="https://github.com/adamcaudill/Base58Check"/>.
+    ///   This is just thin wrapper of <see href="https://github.com/ssg/SimpleBase"/>.
     ///   </para>
     ///   <para>
     ///   This codec uses the BitCoin alphabet <b>not Flickr's</b>.
@@ -34,7 +34,7 @@ namespace Ipfs
         /// </returns>
         public static string Encode(byte[] bytes)
         {
-            return Base58Check.Base58CheckEncoding.EncodePlain(bytes);
+            return SimpleBase.Base58.Bitcoin.Encode(bytes);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Ipfs
         /// </returns>
         public static byte[] Decode(string s)
         {
-            return Base58Check.Base58CheckEncoding.DecodePlain(s);
+            return SimpleBase.Base58.Bitcoin.Decode(s);
         }
 
         /// <summary>

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard16;netstandard2;net45</TargetFrameworks>
     <AssemblyName>Ipfs.Core</AssemblyName>
     <RootNamespace>Ipfs</RootNamespace>
     <DocumentationFile>Ipfs.Core.xml</DocumentationFile>
@@ -30,18 +30,10 @@ The InterPlanetary File System is the permanent web. It is a new hypermedia dist
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="Albireo.Base32" Version="1.0.1">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
-    <PackageReference Include="Base58Check" Version="0.2.0">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="Google.Protobuf" Version="3.4.1" />
-    <PackageReference Include="SHA3" Version="0.9.2">
-      <NoWarn>NU1701</NoWarn>
-    </PackageReference>
+    <PackageReference Include="SimpleBase" Version="1.3.1" />
   </ItemGroup>
  
 

--- a/src/IpfsCore.csproj
+++ b/src/IpfsCore.csproj
@@ -36,5 +36,22 @@ The InterPlanetary File System is the permanent web. It is a new hypermedia dist
     <PackageReference Include="SimpleBase" Version="1.3.1" />
   </ItemGroup>
  
-
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="SHA3">
+      <Version>0.9.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
+    <DefineConstants>SHA3</DefineConstants>
+  </PropertyGroup>
+ 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2'">
+    <PackageReference Include="SHA3">
+      <Version>0.9.2</Version>
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2'">
+    <DefineConstants>SHA3</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/MultiHash.cs
+++ b/src/MultiHash.cs
@@ -127,7 +127,11 @@ namespace Ipfs
             HashingAlgorithm.Register("sha1", 0x11, 20, () => SHA1.Create());
             HashingAlgorithm.Register("sha2-256", 0x12, 32, () => SHA256.Create());
             HashingAlgorithm.Register("sha2-512", 0x13, 64, () => SHA512.Create());
-            HashingAlgorithm.Register("sha3-512", 0x14, 64 /* TODO , () => { return new SHA3.SHA3Managed(512); } */);
+#if SHA3
+            HashingAlgorithm.Register("sha3-512", 0x14, 64, () => { return new SHA3.SHA3Managed(512); });
+#else
+            HashingAlgorithm.Register("sha3-512", 0x14, 64);
+#endif
             HashingAlgorithm.Register("blake2b", 0x40, 64);
             HashingAlgorithm.Register("blake2s", 0x41, 32);
         }

--- a/src/MultiHash.cs
+++ b/src/MultiHash.cs
@@ -124,10 +124,10 @@ namespace Ipfs
         /// </summary>
         static MultiHash()
         {
-            HashingAlgorithm.Register("sha1", 0x11, 20, () => { return new SHA1Managed(); });
-            HashingAlgorithm.Register("sha2-256", 0x12, 32, () => { return new SHA256Managed(); });
-            HashingAlgorithm.Register("sha2-512", 0x13, 64, () => { return new SHA512Managed(); });
-            HashingAlgorithm.Register("sha3-512", 0x14, 64, () => { return new SHA3.SHA3Managed(512); });
+            HashingAlgorithm.Register("sha1", 0x11, 20, () => SHA1.Create());
+            HashingAlgorithm.Register("sha2-256", 0x12, 32, () => SHA256.Create());
+            HashingAlgorithm.Register("sha2-512", 0x13, 64, () => SHA512.Create());
+            HashingAlgorithm.Register("sha3-512", 0x14, 64 /* TODO , () => { return new SHA3.SHA3Managed(512); } */);
             HashingAlgorithm.Register("blake2b", 0x40, 64);
             HashingAlgorithm.Register("blake2s", 0x41, 32);
         }

--- a/src/ProtobufHelper.cs
+++ b/src/ProtobufHelper.cs
@@ -11,17 +11,15 @@ namespace Ipfs
     static class ProtobufHelper
     {
         static MethodInfo writeRawBytes = typeof(CodedOutputStream)
-            .GetMethod("WriteRawBytes",
-                BindingFlags.NonPublic | BindingFlags.Instance,
-                null,
-                new Type[] { typeof(byte[]) },
-                null);
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+            .Single(m =>
+                m.Name == "WriteRawBytes" && m.GetParameters().Count() == 1
+            );
         static MethodInfo readRawBytes = typeof(CodedInputStream)
-             .GetMethod("ReadRawBytes",
-                 BindingFlags.NonPublic | BindingFlags.Instance,
-                 null,
-                 new Type[] { typeof(int) },
-                 null);
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+            .Single(m =>
+                m.Name == "ReadRawBytes"
+            );
 
         public static void WriteSomeBytes(this CodedOutputStream stream, byte[] bytes)
         {

--- a/test/Base32Test.cs
+++ b/test/Base32Test.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Ipfs
 {
     [TestClass]
-    public class EncodeTests
+    public class Base32EncodeTests
     {
         byte[] getStringBytes(string x)
         {
@@ -56,7 +56,7 @@ namespace Ipfs
     }
 
     [TestClass]
-    public class DecodeTests
+    public class Base32DecodeTests
     {
         byte[] getStringBytes(string x)
         {

--- a/test/Base58Test.cs
+++ b/test/Base58Test.cs
@@ -38,7 +38,7 @@ namespace Ipfs
         [TestMethod]
         public void Decode_Bad()
         {
-            ExceptionAssert.Throws<FormatException>(() =>  Base58.Decode("jo91waLQA1NNeBmZKUF=="));
+            ExceptionAssert.Throws<InvalidOperationException>(() =>  Base58.Decode("jo91waLQA1NNeBmZKUF=="));
         }
 
         [TestMethod]

--- a/test/Cryptography/SHA3ManagedTest.cs
+++ b/test/Cryptography/SHA3ManagedTest.cs
@@ -15,9 +15,17 @@ namespace Ipfs.Cryptography
         [TestMethod]
         public void Hashing()
         {
-            var SHA3_512_Hash = "0EAB42DE4C3CEB9235FC91ACFFE746B29C29A8C366B7C60E4E67C466F36A4304C00FA9CAF9D87976BA469BCBE06713B435F091EF2769FB160CDAB33D3670680E";
+            // Some platforms do not support SHA3
+            try
+            {
+                var SHA3_512_Hash = "0EAB42DE4C3CEB9235FC91ACFFE746B29C29A8C366B7C60E4E67C466F36A4304C00FA9CAF9D87976BA469BCBE06713B435F091EF2769FB160CDAB33D3670680E";
 
-            Assert.AreEqual(SHA3_512_Hash, MultiHash.GetHashAlgorithm("sha3-512").ComputeHash(new byte[0]).ToHexString("X"), "sha3-512");
+                Assert.AreEqual(SHA3_512_Hash, MultiHash.GetHashAlgorithm("sha3-512").ComputeHash(new byte[0]).ToHexString("X"), "sha3-512");
+            }
+            catch (NotImplementedException)
+            {
+                // eat it
+            }
         }
     }
 }

--- a/test/IpfsCoreTests.csproj
+++ b/test/IpfsCoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net45</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <DebugType>full</DebugType>
@@ -17,10 +17,5 @@
   <ItemGroup>
     <ProjectReference Include="..\src\IpfsCore.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 
 </Project>

--- a/test/MultiHashTest.cs
+++ b/test/MultiHashTest.cs
@@ -131,9 +131,17 @@ namespace Ipfs
             Assert.IsTrue(mh2.Matches(hello));
             Assert.IsFalse(mh2.Matches(hello1));
 
-            var mh3 = MultiHash.ComputeHash(hello, "sha3-512");
-            Assert.IsTrue(mh3.Matches(hello));
-            Assert.IsFalse(mh3.Matches(hello1));
+            // Some platforms do not support SHA3
+            try
+            {
+                var mh3 = MultiHash.ComputeHash(hello, "sha3-512");
+                Assert.IsTrue(mh3.Matches(hello));
+                Assert.IsFalse(mh3.Matches(hello1));
+            }
+            catch (NotImplementedException)
+            {
+                // eat it
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Add support for .NET Standard 1.6

Tests are run for all supported targets  .NET Framework 4.5, .NET Standard 16 and .NET Standard 2.0

Some issues #26 are still open; specifically SHA3 is not supported on .NET Standard 1.6