### PR TITLE
docfx and and new csproj

### DIFF
--- a/IpfsCore.sln
+++ b/IpfsCore.sln
@@ -1,14 +1,15 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IpfsCore", "src\IpfsCore.csproj", "{6401AF07-B7F2-4664-86AA-FAD99F82DFAD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpfsCoreTests", "test\IpfsCoreTests.csproj", "{FE639401-D4C7-4528-A07C-4290A7710889}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IpfsCoreTests", "test\IpfsCoreTests.csproj", "{FE639401-D4C7-4528-A07C-4290A7710889}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DA715302-8746-4884-95F9-B56F069A0451}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		builddocs.cmd = builddocs.cmd
 		IpfsCore.vsmdi = IpfsCore.vsmdi
 		LICENSE = LICENSE
 		Local.testsettings = Local.testsettings

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,6 @@ cache:
 environment:
   COVERALLS_REPO_TOKEN:
     secure: j4sELCwhVRRjNXFVhjPZjdG4y2itz8jrExhlyDU/lTiLlRQ/P4brB69MGQRFBQae
-  snk_secret:
-    secure: 5QzEIgiDqTIrZruPaIQIvTlNMl5BZ7TGEps7ALyBfHE=
-  git_token:
-    secure: NeX5NCOUXsCLc1UjTJjqB9F02FZ8Wq0VsxqTXC8kBdyK6zjxjebrf/9Da2sY1Kql
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
 # tools we need for bulding/testing/deploying

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - choco install gitversion.portable -pre -y
   - nuget update -self
   #- npm install gh-pages -g
-  #- choco install docfx
+  - choco install docfx -y
   # No longer signing the assembly
   #- nuget install secure-file -ExcludeVersion
   #- if defined snk_secret secure-file\tools\secure-file -decrypt src\ipfs.ci.snk.enc -secret %snk_secret% -out src\ipfs.dev.snk

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,8 @@ build_script:
 after_build:
   - cmd: appveyor PushArtifact "src\bin\%CONFIGURATION%\Ipfs.Core.%GitVersion_MajorMinorPatch%.nupkg"
 # Build documentation in doc\_site
-#  - tools\docfx\docfx doc\docfx.json
+  - cmd: builddocs.cmd
+  - cmd: appveyor PushArtifact doc\_site
 #  - if defined git_token gh-pages -d doc\_site -m "new docs %GitVersion_FullSemVer%"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,11 @@ branches:
 
 for:
 -
-  branches:
+   branches:
     only:
       - master
 
-  environment:
+   environment:
     snk_secret:
       secure: 5QzEIgiDqTIrZruPaIQIvTlNMl5BZ7TGEps7ALyBfHE=
     git_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,6 @@
 version: x-{build}
 
 # branches to build
-branches:
-  # blacklist
-  except:
-    - gh-pages
-
 for:
 -
    branches:
@@ -18,6 +13,11 @@ for:
       secure: 5QzEIgiDqTIrZruPaIQIvTlNMl5BZ7TGEps7ALyBfHE=
     git_token:
       secure: NeX5NCOUXsCLc1UjTJjqB9F02FZ8Wq0VsxqTXC8kBdyK6zjxjebrf/9Da2sY1Kql
+- 
+  branches:
+  # blacklist
+  except:
+    - gh-pages
 
 configuration: Release
 os: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,17 @@ branches:
   except:
     - gh-pages
 
+-
+  branches:
+    only:
+      - master
+
+  environment:
+    snk_secret:
+      secure: 5QzEIgiDqTIrZruPaIQIvTlNMl5BZ7TGEps7ALyBfHE=
+    git_token:
+      secure: NeX5NCOUXsCLc1UjTJjqB9F02FZ8Wq0VsxqTXC8kBdyK6zjxjebrf/9Da2sY1Kql
+
 configuration: Release
 os: Visual Studio 2017
 
@@ -33,7 +44,7 @@ environment:
 install:
   - choco install gitversion.portable -pre -y
   - nuget update -self
-  #- npm install gh-pages -g
+  - npm install gh-pages -g
   - choco install docfx -y
   # No longer signing the assembly
   #- nuget install secure-file -ExcludeVersion
@@ -65,7 +76,7 @@ after_build:
   - cmd: builddocs.cmd
   - cmd: 7z a -tzip docs.zip doc\_site
   - cmd: appveyor PushArtifact docs.zip
-#  - if defined git_token gh-pages -d doc\_site -m "new docs %GitVersion_FullSemVer%"
+  - if defined git_token gh-pages -d doc\_site -m "new docs %GitVersion_FullSemVer%"
 
 test_script:
   - dotnet test -c %CONFIGURATION% --no-build --no-restore test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,10 @@ for:
       secure: 5QzEIgiDqTIrZruPaIQIvTlNMl5BZ7TGEps7ALyBfHE=
     git_token:
       secure: NeX5NCOUXsCLc1UjTJjqB9F02FZ8Wq0VsxqTXC8kBdyK6zjxjebrf/9Da2sY1Kql
+
 - 
   branches:
-  # blacklist
-  except:
+   except:
     - gh-pages
 
 configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ branches:
   except:
     - gh-pages
 
+for:
 -
   branches:
     only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,8 @@ after_build:
   - cmd: appveyor PushArtifact "src\bin\%CONFIGURATION%\Ipfs.Core.%GitVersion_MajorMinorPatch%.nupkg"
 # Build documentation in doc\_site
   - cmd: builddocs.cmd
-  - cmd: appveyor PushArtifact doc\_site
+  - cmd: 7z a -tzip docs.zip doc\_site
+  - cmd: appveyor PushArtifact docs.zip
 #  - if defined git_token gh-pages -d doc\_site -m "new docs %GitVersion_FullSemVer%"
 
 test_script:

--- a/builddocs.cmd
+++ b/builddocs.cmd
@@ -1,0 +1,4 @@
+REM See https://github.com/dotnet/docfx/issues/1752#issuecomment-308909959
+set MSBUILD_EXE_PATH=C:\Program Files\dotnet\sdk\2.0.0\MSBuild.dll
+copy doc\MSBuild.dll.config "C:\Program Files\dotnet\sdk\2.0.0\MSBuild.dll.config" /Y
+docfx doc\docfx.json

--- a/doc/MSBuild.dll.config
+++ b/doc/MSBuild.dll.config
@@ -1,0 +1,112 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+  <configuration>
+    <configSections>
+      <section name="msbuildToolsets" type="Microsoft.Build.Evaluation.ToolsetConfigurationSection, Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    </configSections>
+    <startup useLegacyV2RuntimeActivationPolicy="true">
+      <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+    <runtime>
+      <DisableFXClosureWalk enabled="true" />
+      <generatePublisherEvidence enabled="false" />
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Framework" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Tasks.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Utilities.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Engine" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Build.Conversion.Core" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="15.1.0.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="System.IO.Compression" culture="neutral" publicKeyToken="b77a5c561934e089" />
+          <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.Activities.Build" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href=".\amd64\Microsoft.Activities.Build.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="XamlBuildTask" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+          <bindingRedirect oldVersion="4.0.0.0" newVersion="15.0.0.0" />
+          <codeBase version="15.0.0.0" href=".\amd64\XamlBuildTask.dll" />
+        </dependentAssembly>
+
+        <!-- Workaround for crash in C++ CodeAnalysis scenarios due to https://github.com/Microsoft/msbuild/issues/1675 -->
+        <dependentAssembly>
+          <assemblyIdentity name="FxCopTask" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\FxCopTask.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.dll" />
+        </dependentAssembly>
+        <dependentAssembly>
+          <assemblyIdentity name="Microsoft.VisualStudio.CodeAnalysis.Sdk" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+          <codeBase version="15.0.0.0" href="..\..\Microsoft\VisualStudio\v15.0\CodeAnalysis\Microsoft.VisualStudio.CodeAnalysis.Sdk.dll" />
+        </dependentAssembly>
+      </assemblyBinding>
+    </runtime>
+    <!-- To define one or more new toolsets, add an 'msbuildToolsets' element in this file. -->
+    <msbuildToolsets default="15.0">
+      <toolset toolsVersion="15.0">
+        <property name="MSBuildToolsPath" value="$([MSBuild]::GetCurrentToolsDirectory())" />
+        <property name="MSBuildToolsPath32" value="$([MSBuild]::GetToolsDirectory32())" />
+        <property name="MSBuildToolsPath64" value="$([MSBuild]::GetToolsDirectory64())" />
+        <property name="MSBuildSDKsPath" value="$([MSBuild]::GetMSBuildSDKsPath())" />
+        <property name="FrameworkSDKRoot" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1@InstallationFolder)" />
+        <property name="MSBuildRuntimeVersion" value="4.0.30319" />
+        <property name="MSBuildFrameworkToolsPath" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath32" value="$(SystemRoot)\Microsoft.NET\Framework\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsPath64" value="$(SystemRoot)\Microsoft.NET\Framework64\v$(MSBuildRuntimeVersion)\" />
+        <property name="MSBuildFrameworkToolsRoot" value="$(SystemRoot)\Microsoft.NET\Framework\" />
+        <property name="SDK35ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0A\WinSDK-NetFx35Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
+        <property name="SDK40ToolsPath" value="$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK\4.6.1\WinSDK-NetFx40Tools-x86', 'InstallationFolder', null, RegistryView.Registry32))" />
+        <property name="WindowsSDK80Path" value="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)" />
+        <property name="VsInstallRoot" value="$([MSBuild]::GetVsInstallRoot())" />
+        <property name="MSBuildToolsRoot" value="$(VsInstallRoot)\MSBuild" />
+        <property name="MSBuildExtensionsPath" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+        <property name="MSBuildExtensionsPath32" value="$([MSBuild]::GetMSBuildExtensionsPath())" />
+
+        <property name="RoslynTargetsPath" value="$([MSBuild]::GetToolsDirectory32())\Roslyn" />
+
+        <!-- VC Specific Paths -->
+        <property name="VCTargetsPath" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath)','$(VsInstallRoot)\Common7\IDE\VC\VCTargets\'))" />
+        <property name="VCTargetsPath14" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath14)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V140\'))" />
+        <property name="VCTargetsPath12" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath12)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V120\'))" />
+        <property name="VCTargetsPath11" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath11)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\V110\'))" />
+        <property name="VCTargetsPath10" value="$([MSBuild]::ValueOrDefault('$(VCTargetsPath10)','$([MSBuild]::GetProgramFiles32())\MSBuild\Microsoft.Cpp\v4.0\'))" />
+        <property name="AndroidTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\Android\V150\" />
+        <property name="iOSTargetsPath" value="$(MSBuildExtensionsPath32)\Microsoft\MDD\iOS\V150\" />
+        <projectImportSearchPaths>
+          <searchPaths os="windows">
+            <property name="MSBuildExtensionsPath" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath32" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="MSBuildExtensionsPath64" value="$(MSBuildProgramFiles32)\MSBuild"/>
+            <property name="VSToolsPath" value="$(MSBuildProgramFiles32)\MSBuild\Microsoft\VisualStudio\v$(VisualStudioVersion)"/>
+          </searchPaths>
+        </projectImportSearchPaths>
+      </toolset>
+    </msbuildToolsets>
+  </configuration>

--- a/doc/docfx.json
+++ b/doc/docfx.json
@@ -11,9 +11,12 @@
             "**/bin/**",
             "_site/**"
           ],
-		      "src": ".."
+          "src": ".."
         }
       ],
+      "properties": {
+        "TargetFramework": "net45"
+      },
       "dest": "api"
     }
   ],

--- a/src/MultiHash.cs
+++ b/src/MultiHash.cs
@@ -140,6 +140,10 @@ namespace Ipfs
         /// <summary>
         ///   Gets the <see cref="HashAlgorithm"/> with the specified IPFS multi-hash name.
         /// </summary>
+        /// <param name="name">
+        ///   The name of a hashing algorithm, see <see href="https://github.com/multiformats/multihash/blob/master/hashtable.csv"/>
+        ///   for IPFS defined names.
+        /// </param>
         public static HashAlgorithm GetHashAlgorithm(string name = DefaultAlgorithmName)
         {
             return HashingAlgorithm.Names[name].Hasher();


### PR DESCRIPTION
Build the documentation using docfx.  The `CI` published the  documentation  on the `gh-pages` branch when building on the `master` branch.

Fixes #27

