### PR TITLE
fix(MultiAddress.GetHashCode): aliased protocols give same hashcode #95

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,6 +1,6 @@
 ---
 exclude_paths:
-  - 'test/'
+  - 'test/*'
   - 'test/**/*'
-  - 'doc/'
+  - 'doc/*'
   - 'doc/**/*'

--- a/src/MultiAddress.cs
+++ b/src/MultiAddress.cs
@@ -336,7 +336,14 @@ namespace Ipfs
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return ToString().GetHashCode();
+            int code = 0;
+
+            foreach (var p in Protocols)
+            {
+                code += p.Code.GetHashCode();
+                code += p.Value.GetHashCode();
+            }
+            return code;
         }
 
         /// <inheritdoc />

--- a/src/NetworkProtocol.cs
+++ b/src/NetworkProtocol.cs
@@ -377,9 +377,18 @@ namespace Ipfs
 
     abstract class ValuelessNetworkProtocol : NetworkProtocol
     {
-        public override void ReadValue(CodedInputStream stream) { }
-        public override void ReadValue(TextReader stream) { }
-        public override void WriteValue(CodedOutputStream stream) { }
+        public override void ReadValue(CodedInputStream stream)
+        {
+            // No value to read 
+        }
+        public override void ReadValue(TextReader stream)
+        {
+            // No value to read 
+        }
+        public override void WriteValue(CodedOutputStream stream)
+        {
+            // No value to write
+        }
     }
 
     class QuicNetworkProtocol : ValuelessNetworkProtocol

--- a/test/MultiAddressTest.cs
+++ b/test/MultiAddressTest.cs
@@ -370,7 +370,16 @@ namespace Ipfs
             Assert.AreEqual("/ip4/127.0.0.1/tcp/4001", ma1.WithoutPeerId());
         }
 
+        [TestMethod]
+        public void Alias_Equality()
+        {
+            var a = new MultiAddress("/ipfs/QmQusTXc1Z9C1mzxsqC9ZTFXCgSkpBRGgW4Jk2QYHxKE22");
+            var b = new MultiAddress("/p2p/QmQusTXc1Z9C1mzxsqC9ZTFXCgSkpBRGgW4Jk2QYHxKE22");
 
+            Assert.AreEqual(a, b);
+            Assert.IsTrue(a == b);
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+        }
     }
 }
 


### PR DESCRIPTION
The hash code of a MultiAddress must be passed the protocol's code and value.
So that the aliased protocols give the same hash code.